### PR TITLE
Change login API to use the same link for everyone.

### DIFF
--- a/Backend/Nodejs/routes/login_route.js
+++ b/Backend/Nodejs/routes/login_route.js
@@ -2,59 +2,7 @@ const express = require('express');
 const router = express.Router();
 const passport = require('passport');
 
-router.post('/signin/mentor', async (req, res,next) => {
-    try {
-        const { email, password } = req.body;
-        if (!email || !password) {
-            return res.status(400).json({ err: 'All fields required' });
-        }
-        passport.authenticate('local', (err, user, info) => {
-            if (err) {
-                return res.status(422).send({ error: info });
-            }
-            if (!user) {
-                res.status(401).send({ error: info });
-            } else {
-                req.logIn(user, (error) => {
-                    if (error) {
-                        return res.status(422).send({ error: "Some error occured" });
-                    }
-                    res.status(201).send({ user: user, msg: info });
-                })
-            }
-        })(req, res, next);
-    } catch (err) {
-        res.status(500).json({ error: "Some error occured" });
-    }
-})
-
-router.post('/signin/student', async (req, res, next) => {
-    try {
-        const { email, password } = req.body;
-        if (!email || !password) {
-            return res.status(400).json({ err: 'All fields required' });
-        }
-        passport.authenticate('local', (err, user, info) => {
-            if (err) {
-                return res.status(422).send({ error: info });
-            }
-            if (!user) {
-                res.status(401).send({ error: info });
-            } else {
-                req.logIn(user, (error) => {
-                    if (error) {
-                        return res.status(422).send({ error: "Some error occured" });
-                    }
-                    res.status(201).send({ user: user, msg: info });
-                })
-            }
-        })(req, res, next);
-    } catch (err) {
-        res.status(500).json({ error: "Some error occured" });
-    }
-})
-
-router.post('/signin/ca', async (req, res, next) => {
+router.post('/', async (req, res,next) => {
     try {
         const { email, password } = req.body;
         if (!email || !password) {


### PR DESCRIPTION
Closes #62.

Now the login API uses the same URL to log in student, mentor and CA. Once they are logged in, we can check who they are, by using `user.post`.